### PR TITLE
Fix issues found during testing / preperation for the virtual season

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ install(TARGETS hlvs_player
   DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,8 @@ install(TARGETS hlvs_player
   EXPORT export_${PROJECT_NAME}
   DESTINATION lib/${PROJECT_NAME})
 
-install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
-install(DIRECTORY resources DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY launch resources
+  DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ install(TARGETS hlvs_player
   DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
-install(DIRECTORY config DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY resources DESTINATION share/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In the root of the repository, source your overlay using:
 Run the node using one of these commands:
 
 `ros2 run hlvs_player hlvs_player --ros-args -p host:="127.0.0.1" -p port:=10001`
-`ros2 launch hlvs_player hlvs_player.launch`
+`ros2 launch hlvs_player example.launch`
 
 (you can replace host and port with your preferred ones)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This node is currently available only for ROS 2.
 ## Configuration
 The package comes with the default configuration for a Darwin-OP robot, but you can easily change it to your robot.
 The `resources/devices.json` contains the definition of the devices (sensors and actuators).
-You can set the used network configuration and the ROS topic names via ROS parameters (see `launch/hlvs_player.launch`).
+You can set the used network configuration and the ROS topic names via ROS parameters (see `launch/example.launch`).
 Remember to rebuild the package after changing the json file.
 
 ## Usage

--- a/launch/example.launch
+++ b/launch/example.launch
@@ -1,6 +1,7 @@
 <launch>
   <node pkg="hlvs_player" exec="hlvs_player" output="screen">
     <param name="host" value="127.0.0.1"/>
-    <param name="port" value="10001"/>    
+    <param name="port" value="10001"/>
+    <param name="devices_file" value="$(find-pkg-share hlvs_player)/config/devices.json"/>
   </node>
 </launch>

--- a/launch/example.launch
+++ b/launch/example.launch
@@ -2,6 +2,6 @@
   <node pkg="hlvs_player" exec="hlvs_player" output="screen">
     <param name="host" value="127.0.0.1"/>
     <param name="port" value="10001"/>
-    <param name="devices_file" value="$(find-pkg-share hlvs_player)/config/devices.json"/>
+    <param name="devices_file" value="$(find-pkg-share hlvs_player)/resources/devices.json"/>
   </node>
 </launch>

--- a/resources/devices.json
+++ b/resources/devices.json
@@ -4,9 +4,7 @@
             "proto_camera_name": "Camera",
             "time_step": 16,
             "optical_frame": "camera_optical_frame",
-            "FOV": 1.0123,
-            "width": 320,
-            "height": 240
+            "horizontal_field_of_view": 1.04
         }
     ],
     "IMUs": [

--- a/resources/devices.json
+++ b/resources/devices.json
@@ -9,8 +9,7 @@
     ],
     "IMUs": [
         {
-            "proto_gyro_name": "Gyro",
-            "proto_accel_name": "Accelerometer",
+            "ros_name": "imu",
             "time_step": 8,
             "frame_name": "imu_frame"
         }

--- a/resources/devices.json
+++ b/resources/devices.json
@@ -9,6 +9,8 @@
     ],
     "IMUs": [
         {
+            "proto_gyro_name": "imu gyro",
+            "proto_accel_name": "imu accelerometer",
             "ros_name": "imu",
             "time_step": 8,
             "frame_name": "imu_frame"

--- a/resources/devices.json
+++ b/resources/devices.json
@@ -1,10 +1,8 @@
-{    
+{
     "cameras": [
         {
             "proto_camera_name": "Camera",
             "time_step": 16,
-            "image_topic_name": "camera/image_proc",
-            "info_topic_name": "camera/camera_info",
             "optical_frame": "camera_optical_frame",
             "FOV": 1.0123,
             "width": 320,
@@ -15,13 +13,10 @@
         {
             "proto_gyro_name": "Gyro",
             "proto_accel_name": "Accelerometer",
-            "time_step": 8,            
-            "topic_name": "imu/data_raw",
+            "time_step": 8,
             "frame_name": "imu_frame"
         }
     ],
-    "joint_state_topic_name": "joint_states",
-    "joint_command_topic_name": "joint_commands",
     "joints": [
         {
             "proto_proto_motor_name": "Neck",

--- a/resources/devices.json
+++ b/resources/devices.json
@@ -9,8 +9,8 @@
     ],
     "IMUs": [
         {
-            "proto_gyro_name": "imu gyro",
-            "proto_accel_name": "imu accelerometer",
+            "proto_gyro_name": "Gyro",
+            "proto_accel_name": "Accelerometer",
             "ros_name": "imu",
             "time_step": 8,
             "frame_name": "imu_frame"

--- a/resources/example.json
+++ b/resources/example.json
@@ -4,8 +4,7 @@
             "proto_bumper_name": "bumper1",
             "time_step": 8,
             "frame_name": "bumper1_frame",
-            "frame_axis": "x",
-            "topic_name": "bumper1/data"
+            "frame_axis": "x"
         }
     ],
     "force_sensors_1d": [
@@ -13,24 +12,21 @@
             "proto_sensor_name": "force_sensor1",
             "time_step": 8,
             "frame_name": "force_sensor1_frame",
-            "frame_axis": "x",
-            "topic_name": "force_sensor1/data"
+            "frame_axis": "x"
         }
     ],
     "force_sensors_3d": [
         {
             "proto_sensor_name": "force_sensor3",
             "time_step": 8,
-            "frame_name": "force_sensor3_frame",
-            "topic_name": "force_sensor3/data"
+            "frame_name": "force_sensor3_frame"
         }
     ],
     "force_sensors_6d": [
         {
             "proto_sensor_name": "force_sensor6",
             "time_step": 8,
-            "frame_name": "force_sensor6_frame",
-            "topic_name": "force_sensor6/data"
+            "frame_name": "force_sensor6_frame"
         }
     ]
 }

--- a/src/hlvs_player.cpp
+++ b/src/hlvs_player.cpp
@@ -88,8 +88,7 @@ public:
         map_ros_to_proto_.insert({motor_name, motor_name});
       }
     }
-    joint_state_publisher_ =
-        this->create_publisher<sensor_msgs::msg::JointState>(devices["joint_state_topic_name"].asString(), 10);
+    joint_state_publisher_ = this->create_publisher<sensor_msgs::msg::JointState>("joint_states", 10);
 
     // Bumpers
     for (unsigned int i = 0; i < devices["bumpers"].size(); i++)
@@ -111,7 +110,8 @@ public:
       bumper_sensor->set_name(devices["bumpers"][i]["proto_bumper_name"].asString());
       bumper_sensor->set_timestep(devices["bumpers"][i]["time_step"].asDouble());
       bumper_publishers_.push_back(
-          this->create_publisher<geometry_msgs::msg::WrenchStamped>(devices["bumpers"][i]["topic_name"].asString(), 10));
+          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+            devices["bumpers"][i]["proto_bumper_name"].asString() + "/data", 10));
     }
 
     // Force sensors 1d
@@ -134,7 +134,8 @@ public:
       force1d_sensor->set_name(devices["force_sensors_1d"][i]["proto_sensor_name"].asString());
       force1d_sensor->set_timestep(devices["force_sensors_1d"][i]["time_step"].asDouble());
       force1d_publishers_.push_back(
-          this->create_publisher<geometry_msgs::msg::WrenchStamped>(devices["force_sensors_1d"][i]["topic_name"].asString(), 10));
+          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+            devices["force_sensors_1d"][i]["proto_sensor_name"].asString() + "/data", 10));
     }
 
     // Force sensors 3d
@@ -146,7 +147,8 @@ public:
       force3d_sensor->set_name(devices["force_sensors_3d"][i]["proto_sensor_name"].asString());
       force3d_sensor->set_timestep(devices["force_sensors_3d"][i]["time_step"].asDouble());
       force3d_publishers_.push_back(
-          this->create_publisher<geometry_msgs::msg::WrenchStamped>(devices["force_sensors_3d"][i]["topic_name"].asString(), 10));
+          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+            devices["force_sensors_3d"][i]["proto_sensor_name"].asString() + "/data" , 10));
     }
 
     // Force sensors 6d
@@ -158,7 +160,8 @@ public:
       force6d_sensor->set_name(devices["force_sensors_6d"][i]["proto_sensor_name"].asString());
       force6d_sensor->set_timestep(devices["force_sensors_6d"][i]["time_step"].asDouble());
       force6d_publishers_.push_back(
-          this->create_publisher<geometry_msgs::msg::WrenchStamped>(devices["force_sensors_6d"][i]["topic_name"].asString(), 10));
+          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+            devices["force_sensors_6d"][i]["proto_sensor_name"].asString() + "/data", 10));
     }
 
     // Cameras
@@ -170,13 +173,14 @@ public:
       camera_sensor->set_name(devices["cameras"][i]["proto_camera_name"].asString());
       camera_sensor->set_timestep(devices["cameras"][i]["time_step"].asDouble());
       camera_image_publishers_.push_back(
-          this->create_publisher<sensor_msgs::msg::Image>(devices["cameras"][i]["image_topic_name"].asString(), 10));
+          this->create_publisher<sensor_msgs::msg::Image>(
+            devices["cameras"][i]["proto_camera_name"].asString() + "/image_raw", 10));
 
       // camera info should be latched and only published once
       rclcpp::QoS qos(rclcpp::KeepLast(1));
       qos.transient_local().reliable();
       camera_info_publishers_.push_back(this->create_publisher<sensor_msgs::msg::CameraInfo>(
-          devices["cameras"][i]["info_topic_name"].asString(), qos));
+          devices["cameras"][i]["proto_camera_name"].asString() + "/camera_info", qos));
       // calculate and publish the camera info
       sensor_msgs::msg::CameraInfo camera_info_msg = sensor_msgs::msg::CameraInfo();
       camera_info_msg.header.frame_id = frame_name;
@@ -206,7 +210,8 @@ public:
       sensor->set_name(devices["IMUs"][i]["proto_accel_name"].asString());
       sensor->set_timestep(devices["IMUs"][i]["time_step"].asDouble());
       imu_publishers_.push_back(
-          this->create_publisher<sensor_msgs::msg::Imu>(devices["IMUs"][i]["topic_name"].asString(), 10));
+          this->create_publisher<sensor_msgs::msg::Imu>(
+            devices["IMUs"][i]["proto_gyro_name"].asString() + "/data", 10));
     }
 
     client_->sendRequest(request);

--- a/src/hlvs_player.cpp
+++ b/src/hlvs_player.cpp
@@ -33,11 +33,19 @@ public:
     // Parameters
     this->declare_parameter<std::string>("host", "127.0.0.1");
     this->declare_parameter<int>("port", 10001);
+    this->declare_parameter<std::string>("devices_file", "resources/devices.json");
 
     // Enable devices
     ActuatorRequests request;
     Json::Value devices;
-    std::ifstream json_file("resources/devices.json");
+    std::ifstream json_file(this->get_parameter("devices_file").as_string());
+
+    // Check if file exists
+    if (!json_file.is_open())
+    {
+      RCLCPP_ERROR(this->get_logger(), "Could not open devices file. Please check the 'devices_file' parameter.");
+      return;
+    }
     json_file >> devices;
 
     // Publishers

--- a/src/hlvs_player.cpp
+++ b/src/hlvs_player.cpp
@@ -203,7 +203,7 @@ public:
       sensor->set_timestep(devices["IMUs"][i]["time_step"].asDouble());
       imu_publishers_.push_back(
           this->create_publisher<sensor_msgs::msg::Imu>(
-            devices["IMUs"][i]["proto_gyro_name"].asString() + "/data", 10));
+            devices["IMUs"][i]["ros_name"].asString() + "/data", 10));
     }
 
     client_->sendRequest(request);

--- a/src/hlvs_player.cpp
+++ b/src/hlvs_player.cpp
@@ -57,7 +57,7 @@ public:
 
     // Subscriptions
     motor_command_subscription_ = this->create_subscription<sensor_msgs::msg::JointState>(
-        devices["joint_command_topic_name"].asString(), 10, std::bind(&WebotsController::command_callback, this, _1));
+        "joint_command", 10, std::bind(&WebotsController::command_callback, this, _1));
 
     // Timer and its callback
     // simulation does a step, it does not really make sense to run this in any other frequency
@@ -239,12 +239,12 @@ private:
 
         // publish simulation time
         auto clk = rosgraph_msgs::msg::Clock();
-        clk.clock = rclcpp::Time(measurements.time());
+        clk.clock = ms_to_ros_time(measurements.time());
         clock_publisher_->publish(clk);
         // publish wall clock time of server
         auto ref_clk = sensor_msgs::msg::TimeReference();
-        ref_clk.header.stamp = rclcpp::Time(measurements.real_time());
-        ref_clk.time_ref = rclcpp::Time(measurements.time());
+        ref_clk.header.stamp = ms_to_ros_time(measurements.real_time());
+        ref_clk.time_ref = ms_to_ros_time(measurements.time());
         ref_clk.source = "server";
         real_clock_publisher_->publish(ref_clk);
 
@@ -289,7 +289,7 @@ private:
     for (int i = 0; i < measurements.bumpers_size(); i++)
     {
       auto wrench = geometry_msgs::msg::WrenchStamped();
-      wrench.header.stamp = rclcpp::Time(measurements.time());
+      wrench.header.stamp = ms_to_ros_time(measurements.time());
       wrench.header.frame_id = bumper_frame_names_[i];
       bool bumper_active = measurements.bumpers(i).value();
       // we encode the binary bumper force as 1N as this can then be displayed in RViz
@@ -325,7 +325,7 @@ private:
     for (int i = 0; i < measurements.forces_size(); i++)
     {
       auto wrench = geometry_msgs::msg::WrenchStamped();
-      wrench.header.stamp = rclcpp::Time(measurements.time());
+      wrench.header.stamp = ms_to_ros_time(measurements.time());
       wrench.header.frame_id = force1d_frame_names_[i];
       float force = measurements.forces(i).value();
 
@@ -367,7 +367,7 @@ private:
     for (int i = 0; i < measurements.force3ds_size(); i++)
     {
       auto wrench = geometry_msgs::msg::WrenchStamped();
-      wrench.header.stamp = rclcpp::Time(measurements.time());
+      wrench.header.stamp = ms_to_ros_time(measurements.time());
       wrench.header.frame_id = force3d_frame_names_[i];
       wrench.wrench.force.x = measurements.force3ds(i).value().x();
       wrench.wrench.force.y = measurements.force3ds(i).value().y();
@@ -381,7 +381,7 @@ private:
     for (int i = 0; i < measurements.force6ds_size(); i++)
     {
       auto wrench = geometry_msgs::msg::WrenchStamped();
-      wrench.header.stamp = rclcpp::Time(measurements.time());
+      wrench.header.stamp = ms_to_ros_time(measurements.time());
       wrench.header.frame_id = force6d_frame_names_[i];
       wrench.wrench.force.x = measurements.force6ds(i).force().x();
       wrench.wrench.force.y = measurements.force6ds(i).force().y();
@@ -410,7 +410,7 @@ private:
       cv_bridge::CvImage img_bridge;
       img_bridge = cv_bridge::CvImage(std_msgs::msg::Header(), sensor_msgs::image_encodings::BGR8, img);
       img_bridge.toImageMsg(imgmsg);
-      imgmsg.header.stamp = rclcpp::Time(measurements.time());
+      imgmsg.header.stamp = ms_to_ros_time(measurements.time());
       imgmsg.header.frame_id = camera_frame_names_[i];
       camera_image_publishers_[i]->publish(imgmsg);
     }
@@ -425,7 +425,7 @@ private:
       const GyroMeasurement &gyro_data = measurements.gyros(i);
 
       auto imu_msg = sensor_msgs::msg::Imu();
-      imu_msg.header.stamp = rclcpp::Time(measurements.time());
+      imu_msg.header.stamp = ms_to_ros_time(measurements.time());
       imu_msg.header.frame_id = imu_frame_names_[i];
       imu_msg.linear_acceleration.x = accel_data.value().x();
       imu_msg.linear_acceleration.y = accel_data.value().y();
@@ -449,7 +449,7 @@ private:
       jointmsg.name.push_back(ros_name);
       jointmsg.position.push_back(measurements.position_sensors(i).value());
     }
-    jointmsg.header.stamp = rclcpp::Time(measurements.time());
+    jointmsg.header.stamp = ms_to_ros_time(measurements.time());
     joint_state_publisher_->publish(jointmsg);
   }
 
@@ -499,6 +499,12 @@ private:
   {
     return 2 * atan(tan(h_fov * 0.5) * (height / width));
   }
+
+  rclcpp::Time ms_to_ros_time(u_int32_t ms)
+  {
+    return rclcpp::Time(ms / 1000, (ms % 1000) * 1000000);
+  }
+
   rclcpp::TimerBase::SharedPtr timer_;
 
   rclcpp::Publisher<rosgraph_msgs::msg::Clock>::SharedPtr clock_publisher_;

--- a/src/hlvs_player.cpp
+++ b/src/hlvs_player.cpp
@@ -57,9 +57,10 @@ public:
     std::ifstream json_file(this->get_parameter("devices_file").as_string());
 
     // Check if file exists
-    if (!json_file.is_open())
-    {
-      RCLCPP_ERROR(this->get_logger(), "Could not open devices file. Please check the 'devices_file' parameter.");
+    if (!json_file.is_open()) {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Could not open devices file. Please check the 'devices_file' parameter.");
       return;
     }
     json_file >> devices;
@@ -74,7 +75,7 @@ public:
 
     // Subscriptions
     motor_command_subscription_ = this->create_subscription<sensor_msgs::msg::JointState>(
-        "joint_command", 10, std::bind(&WebotsController::command_callback, this, _1));
+      "joint_command", 10, std::bind(&WebotsController::command_callback, this, _1));
 
     // Timer and its callback
     // simulation does a step, it does not really make sense to run this in any other frequency
@@ -109,7 +110,8 @@ public:
         map_ros_to_proto_.insert({motor_name, motor_name});
       }
     }
-    joint_state_publisher_ = this->create_publisher<sensor_msgs::msg::JointState>("joint_states", 10);
+    joint_state_publisher_ = this->create_publisher<sensor_msgs::msg::JointState>(
+      "joint_states", 10);
 
     // Bumpers
     for (unsigned int i = 0; i < devices["bumpers"].size(); i++) {
@@ -130,8 +132,8 @@ public:
       bumper_sensor->set_name(devices["bumpers"][i]["proto_bumper_name"].asString());
       bumper_sensor->set_timestep(devices["bumpers"][i]["time_step"].asDouble());
       bumper_publishers_.push_back(
-          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
-            devices["bumpers"][i]["proto_bumper_name"].asString() + "/data", 10));
+        this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+          devices["bumpers"][i]["proto_bumper_name"].asString() + "/data", 10));
     }
 
     // Force sensors 1d
@@ -153,8 +155,8 @@ public:
       force1d_sensor->set_name(devices["force_sensors_1d"][i]["proto_sensor_name"].asString());
       force1d_sensor->set_timestep(devices["force_sensors_1d"][i]["time_step"].asDouble());
       force1d_publishers_.push_back(
-          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
-            devices["force_sensors_1d"][i]["proto_sensor_name"].asString() + "/data", 10));
+        this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+          devices["force_sensors_1d"][i]["proto_sensor_name"].asString() + "/data", 10));
     }
 
     // Force sensors 3d
@@ -165,8 +167,8 @@ public:
       force3d_sensor->set_name(devices["force_sensors_3d"][i]["proto_sensor_name"].asString());
       force3d_sensor->set_timestep(devices["force_sensors_3d"][i]["time_step"].asDouble());
       force3d_publishers_.push_back(
-          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
-            devices["force_sensors_3d"][i]["proto_sensor_name"].asString() + "/data" , 10));
+        this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+          devices["force_sensors_3d"][i]["proto_sensor_name"].asString() + "/data", 10));
     }
 
     // Force sensors 6d
@@ -177,8 +179,8 @@ public:
       force6d_sensor->set_name(devices["force_sensors_6d"][i]["proto_sensor_name"].asString());
       force6d_sensor->set_timestep(devices["force_sensors_6d"][i]["time_step"].asDouble());
       force6d_publishers_.push_back(
-          this->create_publisher<geometry_msgs::msg::WrenchStamped>(
-            devices["force_sensors_6d"][i]["proto_sensor_name"].asString() + "/data", 10));
+        this->create_publisher<geometry_msgs::msg::WrenchStamped>(
+          devices["force_sensors_6d"][i]["proto_sensor_name"].asString() + "/data", 10));
     }
 
     // Cameras
@@ -189,9 +191,10 @@ public:
       camera_sensor->set_name(devices["cameras"][i]["proto_camera_name"].asString());
       camera_sensor->set_timestep(devices["cameras"][i]["time_step"].asDouble());
       camera_image_publishers_.push_back(
-          this->create_publisher<sensor_msgs::msg::Image>(
-            devices["cameras"][i]["proto_camera_name"].asString() + "/image_raw", 10));
-      camera_info_publishers_.push_back(this->create_publisher<sensor_msgs::msg::CameraInfo>(
+        this->create_publisher<sensor_msgs::msg::Image>(
+          devices["cameras"][i]["proto_camera_name"].asString() + "/image_raw", 10));
+      camera_info_publishers_.push_back(
+        this->create_publisher<sensor_msgs::msg::CameraInfo>(
           devices["cameras"][i]["proto_camera_name"].asString() + "/camera_info", 10));
       camera_fovs_.push_back(devices["cameras"][i]["horizontal_field_of_view"].asDouble());
     }
@@ -209,8 +212,8 @@ public:
       sensor->set_name(devices["IMUs"][i]["proto_accel_name"].asString());
       sensor->set_timestep(devices["IMUs"][i]["time_step"].asDouble());
       imu_publishers_.push_back(
-          this->create_publisher<sensor_msgs::msg::Imu>(
-            devices["IMUs"][i]["ros_name"].asString() + "/data", 10));
+        this->create_publisher<sensor_msgs::msg::Imu>(
+          devices["IMUs"][i]["ros_name"].asString() + "/data", 10));
     }
 
     client_->sendRequest(request);
@@ -381,10 +384,17 @@ private:
       int width = sensor_data.width();
       camera_info_msg.height = height;
       camera_info_msg.width = width;
-      double f_y = mat_from_fov_and_resolution(h_fov_to_v_fov(camera_fovs_[i], height, width), height);
+      double f_y = mat_from_fov_and_resolution(
+        h_fov_to_v_fov(camera_fovs_[i], height, width), height);
       double f_x = mat_from_fov_and_resolution(camera_fovs_[i], width);
-      camera_info_msg.k = {f_x, 0.0, width / 2.0, 0.0, f_y, height / 2.0, 0.0, 0.0, 1.0};
-      camera_info_msg.p = {f_x, 0.0, width / 2.0, 0.0, 0.0, f_y, height / 2.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+      camera_info_msg.k = {
+        f_x, 0.0, width / 2.0,
+        0.0, f_y, height / 2.0,
+        0.0, 0.0, 1.0};
+      camera_info_msg.p = {
+        f_x, 0.0, width / 2.0, 0.0,
+        0.0, f_y, height / 2.0, 0.0,
+        0.0, 0.0, 1.0, 0.0};
       camera_info_publishers_[i]->publish(camera_info_msg);
     }
   }


### PR DESCRIPTION
Based on #4 

Changes:
- Don't define topics via the json as this seems like a non-standard way of doing this. Instead reasonable defaults are selected and they can easily be remapped by the user. See IPM for a similar discussion.
- Make the json devices file path a parameter
- Check if the json is at the path and give a helpful error if not
- Fix issue where ms are parsed as nanoseconds
- Fix camera info handling (no latch, timestamp, dimensions directly taken from the image)