### PR TITLE
Use ROBOCUP_SIMULATOR_ADDR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,17 @@ Open a new terminal and source your overlay using:
 source install/local_setup.bash
 ```
 
-Run the node using one of these commands:
+Set the simulator address:
 
 ```sh
 # Replace host and port with appropriate values
-ros2 run hlvs_player hlvs_player --ros-args -p host:="127.0.0.1" -p port:=10001
+export ROBOCUP_SIMULATOR_ADDR=127.0.0.1:10001
+```
+
+Run the node using one of these commands:
+
+```sh
+ros2 run hlvs_player hlvs_player
 ros2 launch hlvs_player example.launch
 ```
 

--- a/launch/example.launch
+++ b/launch/example.launch
@@ -1,7 +1,5 @@
 <launch>
   <node pkg="hlvs_player" exec="hlvs_player" output="screen">
-    <param name="host" value="127.0.0.1"/>
-    <param name="port" value="10001"/>
     <param name="devices_file" value="$(find-pkg-share hlvs_player)/resources/devices.json"/>
   </node>
 </launch>


### PR DESCRIPTION
According to the specification, the player always receives the simulator host and port as an environment variable.
Closes #7,