### PR TITLE
Try connecting to the simulator forever

### DIFF
--- a/src/network_client.cpp
+++ b/src/network_client.cpp
@@ -17,7 +17,6 @@
 float NetworkClient::history_period_ = 5;
 // Adding some margin for other data than image
 int NetworkClient::max_answer_size_ = 1920 * 1080 * 3 + 1000;
-int NetworkClient::max_attempts_ = 20;
 int NetworkClient::wait_time_sec_ = 1;
 
 static void close_socket(int fd)
@@ -104,7 +103,7 @@ bool NetworkClient::connectClient()
   }
   int attempt = 1;
   bool connected = false;
-  while (attempt <= max_attempts_) {
+  while (true) {
     if (!rclcpp::ok()) {
       exit(0);
     }
@@ -114,8 +113,8 @@ bool NetworkClient::connectClient()
       break;
     }
     fprintf(
-      stderr, "Failed to connect to %s:%d (attempt %d / %d)\n",
-      host_.c_str(), port_, attempt, max_attempts_);
+      stderr, "Failed to connect to %s:%d (attempt %d)\n",
+      host_.c_str(), port_, attempt);
     attempt++;
     sleep(wait_time_sec_);
   }


### PR DESCRIPTION
Currently, the hlvs_player exists after 20 seconds when no connection to the simulator was established. However, the waiting times are often much longer. Assuming the simulator and the docker containers for the robots are started simultaneously, up to eight robot models have to be loaded into webots before the simulation time starts and the controllers are trying to establish a connection via the API. Our robot model takes approximately 25 seconds to load on one of our high-end workers. So the hlvs_player potentially has to wait around 200s before it can connect.

This pull request simply removes the `max_attempts` so that the player will try connecting as long as the container is running.