### PR TITLE
Use rclcpp version of the events executor

### DIFF
--- a/.github/workflows/build_and_test_rolling.yaml
+++ b/.github/workflows/build_and_test_rolling.yaml
@@ -33,7 +33,3 @@ jobs:
       - uses: ros-tooling/action-ros-ci@v0.3
         with:
           target-ros2-distro: rolling
-          # Specify package name, so tests only run on the packages in this repo even
-          # if we have other packages in the workspace.
-          package-name: hlvs_player
-          vcs-repo-file-url: dependencies.repos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ find_package(std_msgs REQUIRED)
 find_package(rosgraph_msgs REQUIRED)
 find_package(cv_bridge REQUIRED)
 find_package(image_transport REQUIRED)
-find_package(irobot_events_executor REQUIRED)
 find_package(OpenCV REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
 find_package(PkgConfig REQUIRED)
@@ -46,7 +45,6 @@ ament_target_dependencies(hlvs_player
   rosgraph_msgs
   cv_bridge
   image_transport
-  irobot_events_executor
   Protobuf
   OpenCV
   JSONCPP)

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,5 +1,0 @@
-repositories:
-  events-executor:
-    type: git
-    url: https://github.com/irobot-ros/events-executor.git
-    version: main

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,6 @@
 
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
-  <depend>irobot_events_executor</depend>
   <depend>libjsoncpp-dev</depend>
   <depend>protobuf-dev</depend>
   <depend>rosgraph_msgs</depend>

--- a/src/hlvs_player.cpp
+++ b/src/hlvs_player.cpp
@@ -26,7 +26,7 @@
 #include <rclcpp/time.hpp>
 #include <geometry_msgs/msg/wrench_stamped.hpp>
 #include <std_msgs/msg/string.hpp>
-#include <rclcpp/executors/events_executor/events_executor.hpp>
+#include <rclcpp/experimental/executors/events_executor/events_executor.hpp>
 #include <rosgraph_msgs/msg/clock.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
@@ -537,7 +537,7 @@ int main(int argc, char * argv[])
   auto node = std::make_shared<WebotsController>();
 
   // we use the event executor since it greatly reduces the CPU usage
-  rclcpp::executors::EventsExecutor exec;
+  rclcpp::experimental::executors::EventsExecutor exec;
   exec.add_node(node);
   exec.spin();
 


### PR DESCRIPTION
No dependency on the events executor is required as https://github.com/ros2/rclcpp/pull/2155 is merged and released.

Closes: #1 